### PR TITLE
Add a custom OpenAI-compatible LLM endpoint (LiteLLM/Ollama/OpenRouter/self-hosted)

### DIFF
--- a/server/.env.template
+++ b/server/.env.template
@@ -7,3 +7,14 @@ OPEN_WEATHER_KEY=XXX
 BING_KEY=XXX
 FINNHUB_KEY=XXX
 WOLFRAM_KEY=XXX
+
+# --- Custom OpenAI-compatible LLM endpoint ---------------------------------
+# Select the "custom" model on a device to route completions here. Point at
+# LiteLLM, Ollama, OpenRouter, or any OpenAI-compatible gateway.
+# Provide EITHER the base URL (…/v1) or the full chat-completions URL.
+CUSTOM_LLM_BASE=https://your-gateway.example.com/v1
+# CUSTOM_LLM_ENDPOINT=https://your-gateway.example.com/v1/chat/completions
+CUSTOM_LLM_MODEL=gpt-4o-mini
+CUSTOM_LLM_KEY=XXX
+# Set to "false" if the target model does not support tool/function calling.
+CUSTOM_LLM_TOOLS=true

--- a/server/src/config/davis.ts
+++ b/server/src/config/davis.ts
@@ -33,8 +33,9 @@ export const COMP_MODELS: RequireOne<
     endpoint: customEndpoint(),
     name: process.env.CUSTOM_LLM_MODEL ?? "gpt-4o-mini",
     supportsTools: process.env.CUSTOM_LLM_TOOLS !== "false",
-    getKey: () =>
-      (process.env.CUSTOM_LLM_KEY ?? process.env.OPENAI_KEY) as string,
+    // Empty string (not undefined) when unset — keyless self-hosted gateways
+    // (e.g. Ollama) accept it, and it avoids sending "Bearer undefined".
+    getKey: () => process.env.CUSTOM_LLM_KEY ?? process.env.OPENAI_KEY ?? "",
   },
   "gpt-4o-mini": {
     endpoint: "https://api.openai.com/v1/chat/completions",

--- a/server/src/config/davis.ts
+++ b/server/src/config/davis.ts
@@ -8,10 +8,28 @@ export const COMP_CALLS_EXCEEDED_MSG = `Failed to get a response from Davis in $
 
 type RequireOne<T, K extends keyof T> = Partial<T> & Required<Pick<T, K>>;
 
+// Resolve the full chat-completions URL for the user-supplied custom endpoint.
+// Accepts either CUSTOM_LLM_ENDPOINT (full URL) or CUSTOM_LLM_BASE (…/v1).
+const customEndpoint = (): string => {
+  if (process.env.CUSTOM_LLM_ENDPOINT) return process.env.CUSTOM_LLM_ENDPOINT;
+  const base = process.env.CUSTOM_LLM_BASE;
+  if (base) return `${base.replace(/\/+$/, "")}/chat/completions`;
+  return "https://api.openai.com/v1/chat/completions";
+};
+
 export const COMP_MODELS: RequireOne<
   Record<LanguageModelKey, AuthenticatedCompletionModel>,
   "gpt-4o-mini"
 > = {
+  // Point at any OpenAI-compatible endpoint (LiteLLM, Ollama, OpenRouter, a
+  // self-hosted gateway, …) via env. Works for both text and vision.
+  custom: {
+    endpoint: customEndpoint(),
+    name: process.env.CUSTOM_LLM_MODEL ?? "gpt-4o-mini",
+    supportsTools: process.env.CUSTOM_LLM_TOOLS !== "false",
+    getKey: () =>
+      (process.env.CUSTOM_LLM_KEY ?? process.env.OPENAI_KEY) as string,
+  },
   "gpt-4o-mini": {
     endpoint: "https://api.openai.com/v1/chat/completions",
     name: "gpt-4o-mini",

--- a/server/src/config/davis.ts
+++ b/server/src/config/davis.ts
@@ -6,6 +6,12 @@ import { SEXY_PROMPT } from "./sexyMode";
 export const COMP_MAX_CALLS = 5;
 export const COMP_CALLS_EXCEEDED_MSG = `Failed to get a response from Davis in ${COMP_MAX_CALLS} calls.`;
 
+// Spoken to the user when the custom endpoint is unreachable, times out, or
+// errors — the device is screenless, so it must hear something speakable
+// instead of a hard error.
+export const CUSTOM_LLM_UNREACHABLE_MSG =
+  "My brain is unreachable right now — try again in a moment.";
+
 type RequireOne<T, K extends keyof T> = Partial<T> & Required<Pick<T, K>>;
 
 // Resolve the full chat-completions URL for the user-supplied custom endpoint.

--- a/server/src/config/deviceSettings.ts
+++ b/server/src/config/deviceSettings.ts
@@ -11,6 +11,12 @@ export interface ModelInterfaces {
 export const LANGUAGE_MODELS = [
   { value: "gpt-4o", label: "GPT-4o", supportVision: true },
   { value: "gpt-4o-mini", label: "GPT-4o Mini", supportText: true },
+  {
+    value: "custom",
+    label: "Custom (OpenAI-compatible)",
+    supportText: true,
+    supportVision: true,
+  },
   { value: "grok-2-sexy", label: "Grok 2 (Sexy Mode)", supportText: true },
   { value: "grok-3", label: "Grok 3" },
   { value: "llama-3-2-11b", label: "Llama 3.2 11B" },

--- a/server/src/davis/index.ts
+++ b/server/src/davis/index.ts
@@ -10,7 +10,7 @@ import { functions, FunctionHandlerError } from "./functions";
 import { COMP_MAX_CALLS, COMP_MODELS } from "../config/davis";
 import { DeviceContext } from "src/endpoints/device/voice/common";
 import { DeviceNote, getDeviceNotes } from "src/services/database/device/notes";
-import { COMP_CALLS_EXCEEDED_MSG } from "src/config/davis";
+import { COMP_CALLS_EXCEEDED_MSG, CUSTOM_LLM_UNREACHABLE_MSG } from "src/config/davis";
 import { getNoteSlug } from "./functions/handlers/upsertNote";
 import { WithId } from "src/services/database/device/content";
 import { addHours } from "date-fns/addHours";
@@ -217,11 +217,23 @@ class DavisEngine {
   }
 
   private async doCompletionIteration(): Promise<string | undefined> {
-    const assistantMsg = await doChatCompletion(
-      this.getModel(),
-      this.completionMsgs,
-      functions.map((f) => f.definition)
-    );
+    const model = this.getModel();
+
+    let assistantMsg;
+    try {
+      assistantMsg = await doChatCompletion(
+        model,
+        this.completionMsgs,
+        functions.map((f) => f.definition)
+      );
+    } catch (error) {
+      // Only the user-supplied custom endpoint gets a spoken fallback;
+      // other providers keep their existing error behavior
+      if (model !== COMP_MODELS.custom) throw error;
+
+      console.warn("Custom LLM endpoint failed", error);
+      return CUSTOM_LLM_UNREACHABLE_MSG;
+    }
 
     this.completionMsgs.push(assistantMsg);
     const toolCalls = assistantMsg.tool_calls || [];


### PR DESCRIPTION
## Why
`COMP_MODELS` hardcodes OpenAI/x.ai completion URLs, so there is no supported way to point the assistant at a self-hosted or alternative OpenAI-compatible gateway (LiteLLM, Ollama, OpenRouter, a private proxy). Self-hosters currently have to patch source.

## What
Adds a **`custom`** model, selectable per device, that routes completions to any OpenAI-compatible endpoint via environment variables. Works for both text and vision.

- `deviceSettings.ts`: new `custom` entry (`supportText` + `supportVision`).
- `config/davis.ts`: `custom` entry in `COMP_MODELS`.
  - `CUSTOM_LLM_BASE` (`…/v1`) **or** `CUSTOM_LLM_ENDPOINT` (full chat-completions URL)
  - `CUSTOM_LLM_MODEL` (defaults to `gpt-4o-mini`)
  - `CUSTOM_LLM_KEY` (falls back to `OPENAI_KEY`)
  - `CUSTOM_LLM_TOOLS=false` to disable tool calling for models that lack it
- `.env.template` documents the variables.

## Compatibility
Purely additive. When unconfigured, `custom` targets OpenAI just like the existing models. No changes to existing models, sockets, tool definitions, or the client. `tsc --noEmit` passes for the changed files (pre-existing `keys/firebaseKey` template errors are unrelated).