### PR TITLE
Fix pairing 411 Length Required behind strict frontends (Cloud Run)

### DIFF
--- a/client/appframework/src/main/java/org/openpin/appframework/daemonbridge/process/RequestProcess.kt
+++ b/client/appframework/src/main/java/org/openpin/appframework/daemonbridge/process/RequestProcess.kt
@@ -95,6 +95,12 @@ class RequestProcess(
                     cmd.add(flag)
                     cmd.add(payload.toCurlArg())
                 }
+            } else if (method.uppercase() !in listOf("GET", "HEAD")) {
+                // curl omits Content-Length when no payload is given, and strict
+                // frontends (e.g. Google Cloud Run) reject bodyless POSTs without
+                // it with "411 Length Required"
+                cmd.add("-H")
+                cmd.add("\"Content-Length: 0\"")
             }
 
             // Query parameters


### PR DESCRIPTION
## Why
Pairing fails when the backend is deployed behind a strict HTTP frontend (e.g. Google Cloud Run): the device's pair request comes back `curl: (22) ... 411 Length Required` and the Pin can never link (#7).

## Root cause
`RequestProcess.buildCurlCommand` builds the pair request as a bodyless POST — `curl -sSf -X POST <url>` with no data flag (`/api/dev/pair/:pairCode` carries no payload). When curl gets `-X POST` without any `--data*` option it sends **no `Content-Length` header at all**, captured on the wire:

```
POST /api/dev/pair/abc HTTP/1.1
Host: ...
User-Agent: curl/8.7.1
Accept: */*
```

Google's frontend rejects bodyless POSTs without `Content-Length` before they ever reach the Express app. Reproducible against a live Google frontend over HTTP/1.1:

```
$ curl -o /dev/null -w '%{http_code}' --http1.1 -X POST https://storage.googleapis.com/x
411
$ curl -o /dev/null -w '%{http_code}' --http1.1 -X POST -H "Content-Length: 0" https://storage.googleapis.com/x
400   # past the frontend, handled by the app layer
```

The server code itself is fine — nothing in `server/src` emits 411, so no backend change can fix this; it has to be fixed where the request is built.

## What
`RequestProcess.buildCurlCommand` now adds an explicit `Content-Length: 0` header whenever a non-GET/HEAD request is built without a payload. Verified on the wire that the header is emitted. This covers pairing today and any future bodyless POSTs sent through `RequestProcess`.

## Compatibility
- Pure request-builder change in `appframework`; no server, socket, or API changes.
- `Content-Length: 0` on a bodyless POST is what permissive servers already assumed, so existing deployments are unaffected.
- An explicit header (rather than `--data ""`) avoids curl adding an implicit `Content-Type: application/x-www-form-urlencoded`.
- Server `tsc --noEmit` passes (unchanged, sanity check).

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
