### PR TITLE
Make speech (STT/TTS) provider-agnostic (SPEECH_PROVIDER, OpenAI-compatible backends)

### DIFF
--- a/server/.env.template
+++ b/server/.env.template
@@ -1,4 +1,4 @@
-SPEECH_KEY=XXX
+MSFT_SPEECH_KEY=XXX
 OPENAI_KEY=XXX
 GROQ_KEY=XXX
 GROK_KEY=XXX
@@ -7,3 +7,20 @@ OPEN_WEATHER_KEY=XXX
 BING_KEY=XXX
 FINNHUB_KEY=XXX
 WOLFRAM_KEY=XXX
+
+# --- Speech (STT + TTS) provider ---------------------------------------------
+# "azure"  : stock pipeline — Azure Speech for TTS (MSFT_SPEECH_KEY above) and
+#            Groq-hosted Whisper for STT (GROQ_KEY). Default.
+# "openai" : any OpenAI-compatible audio API (OpenAI, a LiteLLM proxy,
+#            self-hosted faster-whisper / openedai-speech, ...) via
+#            POST /audio/transcriptions and POST /audio/speech.
+# If SPEECH_PROVIDER is unset, "openai" is used when OPENAI_SPEECH_BASE is
+# configured, otherwise "azure".
+SPEECH_PROVIDER=azure
+OPENAI_SPEECH_BASE=https://api.openai.com/v1
+OPENAI_SPEECH_KEY=XXX
+OPENAI_STT_MODEL=whisper-1
+OPENAI_TTS_MODEL=tts-1
+# Voice name understood by your provider (the dashboard voice picker maps to
+# Azure voices and only applies to the "azure" provider).
+OPENAI_TTS_VOICE=alloy

--- a/server/src/services/audio.ts
+++ b/server/src/services/audio.ts
@@ -23,6 +23,42 @@ export const changeVolume = (inputBuffer: Buffer, volume: number): Promise<Buffe
   });
 };
 
+export interface TranscodeOptions {
+  /** Output sample rate in Hz (default 16 kHz, like Azure TTS). */
+  sampleRate?: number;
+  /** Output channel count (default mono). */
+  channels?: number;
+}
+
+/*
+ * Transcode any ffmpeg-readable audio buffer to an Ogg buffer with the given
+ * sample rate / channel count. Used to normalize third-party TTS output to
+ * the profile the device pipeline expects (Ogg, 16 kHz, mono).
+ */
+export const transcodeToOgg = (
+  inputBuffer: Buffer,
+  { sampleRate = 16000, channels = 1 }: TranscodeOptions = {}
+): Promise<Buffer> => {
+  return new Promise((resolve, reject) => {
+    const inputStream = streamifier.createReadStream(inputBuffer);
+    const outputStream = new PassThrough();
+    const chunks: Buffer[] = [];
+
+    ffmpeg(inputStream)
+      .audioFrequency(sampleRate)
+      .audioChannels(channels)
+      .format("ogg")
+      .on("error", reject)
+      .on("end", () => {
+        resolve(Buffer.concat(chunks));
+      })
+      .pipe(outputStream, { end: true });
+
+    outputStream.on("data", (chunk) => chunks.push(chunk));
+    outputStream.on("error", reject);
+  });
+};
+
 export const getPeakVolume = (inputBuffer: Buffer): Promise<number> => {
   return new Promise((resolve, reject) => {
     const inputStream = streamifier.createReadStream(inputBuffer);

--- a/server/src/services/audio.ts
+++ b/server/src/services/audio.ts
@@ -49,12 +49,12 @@ export const transcodeToOgg = (
       .audioChannels(channels)
       .format("ogg")
       .on("error", reject)
-      .on("end", () => {
-        resolve(Buffer.concat(chunks));
-      })
       .pipe(outputStream, { end: true });
 
     outputStream.on("data", (chunk) => chunks.push(chunk));
+    // Resolve on the output stream's end, not ffmpeg's — ffmpeg can signal
+    // "end" while the last chunks are still buffered in the PassThrough.
+    outputStream.on("end", () => resolve(Buffer.concat(chunks)));
     outputStream.on("error", reject);
   });
 };

--- a/server/src/services/speech/SST.ts
+++ b/server/src/services/speech/SST.ts
@@ -3,26 +3,28 @@ import { GROQ_SST_MODEL } from "src/config";
 import FormData from "form-data";
 import { getPeakVolume } from "../audio";
 import { WHISPER_MIN_DB } from "src/config/speechRecognition";
+import {
+  env,
+  getOpenaiSpeechBase,
+  getOpenaiSpeechHeaders,
+  resolveSpeechProvider,
+} from "./provider";
 
 export class NoRecognitionError extends Error {
-  constructor(message: string = "No speech recognized") {
+  constructor(message = "No speech recognized") {
     super(message);
     this.name = "NoRecognitionError";
   }
 }
 
-const whisperClient = axios.create({
-  baseURL: "https://api.groq.com/openai/v1",
-  headers: {
-    Authorization: `Bearer ${process.env.GROQ_KEY as string}`,
-  },
-});
-
-export const recognize = async (audioBuffer: Buffer): Promise<string> => {
-  const maxVolume = await getPeakVolume(audioBuffer);
-  if (maxVolume < WHISPER_MIN_DB) {
-    throw new NoRecognitionError();
-  }
+// Stock ("azure") pipeline: Whisper hosted on Groq
+const recognizeGroq = async (audioBuffer: Buffer): Promise<string> => {
+  const whisperClient = axios.create({
+    baseURL: "https://api.groq.com/openai/v1",
+    headers: {
+      Authorization: `Bearer ${process.env.GROQ_KEY as string}`,
+    },
+  });
 
   const formData = new FormData();
   formData.append("file", audioBuffer, "audio.ogg");
@@ -31,4 +33,33 @@ export const recognize = async (audioBuffer: Buffer): Promise<string> => {
   const response = await whisperClient.post("/audio/transcriptions", formData);
 
   return response.data.text;
+};
+
+// Any OpenAI-compatible /audio/transcriptions endpoint
+const recognizeOpenai = async (audioBuffer: Buffer): Promise<string> => {
+  const formData = new FormData();
+  formData.append("file", audioBuffer, "audio.ogg");
+  formData.append("model", env("OPENAI_STT_MODEL") ?? "whisper-1");
+
+  const response = await axios.post(
+    `${getOpenaiSpeechBase()}/audio/transcriptions`,
+    formData,
+    { headers: getOpenaiSpeechHeaders() }
+  );
+
+  return response.data.text;
+};
+
+export const recognize = async (audioBuffer: Buffer): Promise<string> => {
+  const maxVolume = await getPeakVolume(audioBuffer);
+  if (maxVolume < WHISPER_MIN_DB) {
+    throw new NoRecognitionError();
+  }
+
+  switch (resolveSpeechProvider()) {
+  case "openai":
+    return recognizeOpenai(audioBuffer);
+  case "azure":
+    return recognizeGroq(audioBuffer);
+  }
 };

--- a/server/src/services/speech/TTS.ts
+++ b/server/src/services/speech/TTS.ts
@@ -89,6 +89,7 @@ const speakOpenai = async (
     {
       headers: getOpenaiSpeechHeaders(),
       responseType: "arraybuffer",
+      timeout: 30000,
     }
   );
 

--- a/server/src/services/speech/TTS.ts
+++ b/server/src/services/speech/TTS.ts
@@ -1,5 +1,13 @@
 import * as MsftSpeech from "microsoft-cognitiveservices-speech-sdk";
+import axios from "axios";
 import { MSFT_TTS_FORMAT, MSFT_TTS_REGION } from "src/config";
+import { transcodeToOgg } from "../audio";
+import {
+  env,
+  getOpenaiSpeechBase,
+  getOpenaiSpeechHeaders,
+  resolveSpeechProvider,
+} from "./provider";
 
 export const getMsftSpeechConfig = () => {
   const speechConfig = MsftSpeech.SpeechConfig.fromSubscription(
@@ -24,7 +32,7 @@ export interface SynthesisConfig {
   language: string;
 }
 
-export const speak = async (
+const speakAzure = async (
   text: string,
   config: SynthesisConfig
 ): Promise<Buffer> => {
@@ -50,4 +58,54 @@ export const speak = async (
       }
     );
   });
+};
+
+/*
+ * Any OpenAI-compatible /audio/speech endpoint.
+ *
+ * The voice comes from OPENAI_TTS_VOICE (the dashboard voice picker maps to
+ * Azure voice names, which mean nothing to other providers); `config.language`
+ * has no equivalent parameter and is ignored. `config.speed` is passed
+ * through — both Azure prosody rate and the OpenAI `speed` field are 1.0-based
+ * multipliers.
+ *
+ * We request Ogg/Opus and then transcode to 16 kHz mono Ogg so the rest of
+ * the pipeline (ffmpeg post-processing + the device) sees the same audio
+ * profile Azure produces (Ogg16Khz16BitMonoOpus).
+ */
+const speakOpenai = async (
+  text: string,
+  config: SynthesisConfig
+): Promise<Buffer> => {
+  const response = await axios.post(
+    `${getOpenaiSpeechBase()}/audio/speech`,
+    {
+      model: env("OPENAI_TTS_MODEL") ?? "tts-1",
+      voice: env("OPENAI_TTS_VOICE") ?? "alloy",
+      input: text,
+      response_format: "opus",
+      speed: Math.min(Math.max(config.speed, 0.25), 4),
+    },
+    {
+      headers: getOpenaiSpeechHeaders(),
+      responseType: "arraybuffer",
+    }
+  );
+
+  return transcodeToOgg(Buffer.from(response.data), {
+    sampleRate: 16000,
+    channels: 1,
+  });
+};
+
+export const speak = async (
+  text: string,
+  config: SynthesisConfig
+): Promise<Buffer> => {
+  switch (resolveSpeechProvider()) {
+  case "openai":
+    return speakOpenai(text, config);
+  case "azure":
+    return speakAzure(text, config);
+  }
 };

--- a/server/src/services/speech/provider.ts
+++ b/server/src/services/speech/provider.ts
@@ -1,0 +1,42 @@
+/**
+ * Provider selection for speech (STT + TTS).
+ *
+ * The stock pipeline is Azure Speech for synthesis (MSFT_SPEECH_KEY) and
+ * Groq-hosted Whisper for recognition (GROQ_KEY). Set SPEECH_PROVIDER to:
+ *   - "azure"  : the stock pipeline above (default)
+ *   - "openai" : any OpenAI-compatible audio API — OpenAI itself, a LiteLLM
+ *                proxy, self-hosted faster-whisper / openedai-speech, etc. —
+ *                using POST /audio/transcriptions and POST /audio/speech.
+ * If SPEECH_PROVIDER is unset, "openai" is used when OPENAI_SPEECH_BASE is
+ * configured, otherwise "azure".
+ */
+
+export type SpeechProvider = "azure" | "openai";
+
+export const env = (name: string) => {
+  const v = process.env[name];
+  return v && v !== "XXX" ? v : undefined;
+};
+
+export const resolveSpeechProvider = (): SpeechProvider => {
+  const explicit = process.env.SPEECH_PROVIDER?.toLowerCase();
+  if (explicit === "azure" || explicit === "openai") return explicit;
+  return env("OPENAI_SPEECH_BASE") ? "openai" : "azure";
+};
+
+export const getOpenaiSpeechBase = (): string => {
+  const base = env("OPENAI_SPEECH_BASE");
+  if (!base) {
+    throw new Error(
+      "SPEECH_PROVIDER=openai requires OPENAI_SPEECH_BASE " +
+        "(e.g. https://api.openai.com/v1 or a LiteLLM/self-hosted base URL)."
+    );
+  }
+  return base.replace(/\/+$/, "");
+};
+
+// Auth header for the OpenAI-compatible endpoint (optional for self-hosted)
+export const getOpenaiSpeechHeaders = (): Record<string, string> => {
+  const key = env("OPENAI_SPEECH_KEY");
+  return key ? { Authorization: `Bearer ${key}` } : {};
+};


### PR DESCRIPTION
## Why
Speech is the last assistant-critical service that's hard-wired to specific vendors: TTS requires an **Azure Speech** key (`MSFT_SPEECH_KEY`) and STT a **Groq** key, with no way to point either at a different backend. Same single-vendor situation as search/weather before #8 — anyone without those exact keys (or running fully self-hosted) has no voice pipeline at all.

## What
Speech is now provider-selectable via `SPEECH_PROVIDER` (`server/src/services/speech/`):

- **`azure`** (default) — the stock pipeline, byte-for-byte unchanged: Azure Speech synthesis + Groq-hosted Whisper recognition. (Naming note: STT was already Groq, not Azure; "azure" here just means "the stock stack".)
- **`openai`** — any OpenAI-compatible audio API via `POST /audio/transcriptions` (multipart) and `POST /audio/speech`: OpenAI itself, a LiteLLM proxy, self-hosted faster-whisper / Speaches, openedai-speech, etc. Configured with `OPENAI_SPEECH_BASE`, `OPENAI_SPEECH_KEY` (optional for keyless self-hosted servers), `OPENAI_STT_MODEL` (default `whisper-1`), `OPENAI_TTS_MODEL` (default `tts-1`), `OPENAI_TTS_VOICE` (default `alloy`).

If `SPEECH_PROVIDER` is unset, `openai` is auto-selected only when `OPENAI_SPEECH_BASE` is configured — otherwise behavior is exactly as today.

## Audio formats (the honest part)
- Azure TTS returns `Ogg16Khz16BitMonoOpus`, and the downstream pipeline depends on that: `changeVolume` / `addBackgroundAudio` force `inputFormat("ogg")` before the audio reaches the device.
- The OpenAI provider therefore requests `response_format: "opus"` (Ogg/Opus, 48 kHz) and **transcodes to Ogg 16 kHz mono** with the ffmpeg toolchain the server already uses (new `transcodeToOgg` helper in `services/audio.ts`), so everything downstream sees the same profile regardless of provider. One extra ffmpeg pass per response; no client/device changes.
- `recognize()` interface unchanged (`Buffer` in → transcript out); the device's Ogg capture buffer is uploaded as `audio.ogg`, which Whisper-style endpoints accept natively. The silence gate (`WHISPER_MIN_DB`) stays provider-independent.
- The dashboard voice picker maps to Azure voice names, so it only applies to the `azure` provider; the `openai` provider takes its voice from `OPENAI_TTS_VOICE`. `speed` carries over cleanly (both are 1.0-based multipliers, clamped to OpenAI's 0.25–4 range). The translate feature's language-identifying STT (Google Speech v2) is a separate code path and is intentionally left untouched.

## Compatibility & verification
- Azure/Groq deployments: zero behavior change (default provider, code path untouched).
- `.env.template` documents the new block and fixes the stale `SPEECH_KEY` name — the code reads `MSFT_SPEECH_KEY`.
- `tsc --noEmit` clean; new files lint clean.
- Smoke-tested both directions against an OpenAI-compatible stub: multipart STT (auth header, model field, filename) and TTS request shape verified, output confirmed Ogg / 16 kHz / mono via ffprobe and accepted by the existing `changeVolume` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)