### PR TITLE
Answer card: project the reply text on the laser display while it is spoken

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -1,0 +1,21 @@
+name: client-ci
+on:
+  push:
+    paths: ["client/**", ".github/workflows/client-ci.yml"]
+  pull_request:
+    paths: ["client/**"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Build client (assembleDebug)
+        working-directory: client
+        run: ./gradlew assembleDebug --console=plain

--- a/client/apps/primaryapp/src/main/java/org/openpin/primaryapp/GestureManager.kt
+++ b/client/apps/primaryapp/src/main/java/org/openpin/primaryapp/GestureManager.kt
@@ -20,8 +20,10 @@ import org.openpin.appframework.sensors.microphone.RecordSession
 import org.openpin.appframework.media.soundplayer.withLoadingSounds
 import org.openpin.appframework.sensors.camera.CaptureResult
 import org.openpin.appframework.sensors.camera.CaptureSession
+import org.openpin.appframework.ui.controllers.NavigationController
 import org.openpin.primaryapp.backend.BackendManager
 import org.openpin.primaryapp.gestureinterpreter.InterpreterMode
+import org.openpin.primaryapp.views.AnswerCardView
 import java.io.File
 
 class GestureManager(
@@ -44,6 +46,8 @@ class GestureManager(
 
     private var speechCapture: RecordSession? = null
     private var videoCaptureSession: CaptureSession<Uri>? = null
+
+    private var navigationController: NavigationController? = null
 
     private var voiceInputStart: Long = 0
 
@@ -112,6 +116,14 @@ class GestureManager(
 
     fun addListeners() {
         gestureInterpreter.subscribeGestures()
+    }
+
+    /**
+     * Attaches the navigation controller used to project the answer card
+     * while a reply is being spoken.
+     */
+    fun attachNavigationController(navigationController: NavigationController) {
+        this.navigationController = navigationController
     }
 
     fun enableSettingsToggle(onToggle: (Boolean) -> Unit) {
@@ -267,12 +279,25 @@ class GestureManager(
                     backendManager.sendVoiceRequest(endpoint, capture.result, imgFile)
                 }
 
-                res?.let {
+                res?.let { response ->
                     gestureInterpreter.setMode(InterpreterMode.CANCELABLE)
                     state = State.VOICE_RESPONDING
 
-                    speechPlayer.play(it)
-                    speechPlayer.awaitPlaybackCompletion()
+                    // Project the reply text while it is being spoken, if the
+                    // server included it in the response metadata.
+                    val nav = navigationController
+                    val answerText = response.text?.trim()
+                    val showCard = nav != null && !answerText.isNullOrEmpty()
+                    if (showCard) nav?.push { AnswerCardView(answerText!!) }
+
+                    try {
+                        speechPlayer.play(response.audio)
+                        speechPlayer.awaitPlaybackCompletion()
+                    } finally {
+                        // Dismiss when playback completes naturally or is
+                        // cancelled by the gesture handled in handleCancel()
+                        if (showCard) nav?.pop()
+                    }
                 }
             } catch (err: Exception) {
                 Log.e("Assistant", "Failed to complete voice request: ${err.message}")

--- a/client/apps/primaryapp/src/main/java/org/openpin/primaryapp/MainActivity.kt
+++ b/client/apps/primaryapp/src/main/java/org/openpin/primaryapp/MainActivity.kt
@@ -63,6 +63,7 @@ class MainActivity : PinActivity() {
         val navigationController = NavigationController().apply {
             init { HomeView(navigationController = this) }
         }
+        gestureManager.attachNavigationController(navigationController)
         setGraphicsContent {
             AppContainer(navigationController = navigationController)
         }

--- a/client/apps/primaryapp/src/main/java/org/openpin/primaryapp/backend/BackendManager.kt
+++ b/client/apps/primaryapp/src/main/java/org/openpin/primaryapp/backend/BackendManager.kt
@@ -33,7 +33,19 @@ data class ResponseMetadata(
     val bt: Boolean,
     val gnss: Boolean,
     val spkVol: Float,
-    val lLevel: Float
+    val lLevel: Float,
+    /**
+     * Plain text of the assistant reply, if the server includes it in the
+     * response metadata. Optional and backwards-compatible: older servers
+     * that omit it simply yield null.
+     */
+    val text: String? = null
+)
+
+/** A voice-endpoint response: the TTS audio plus optional reply text. */
+class VoiceResponse(
+    val audio: ByteArray,
+    val text: String?
 )
 
 data class PairDetails(
@@ -220,7 +232,7 @@ class BackendManager(
         }
     }
 
-    suspend fun sendVoiceRequest(endpoint: String, audioFile: File, imageFile: File?): ByteArray? {
+    suspend fun sendVoiceRequest(endpoint: String, audioFile: File, imageFile: File?): VoiceResponse? {
         // Todo: clean up logic into multiple fns
         val baseUrl = configurationManager.getString(ConfigKey.BACKEND_BASE_URL)!!
         val deviceId = configurationManager.getString(ConfigKey.DEVICE_ID)!!
@@ -287,7 +299,7 @@ class BackendManager(
                 input.readBytes()
             }
 
-            return audioBytes
+            return VoiceResponse(audioBytes, responseMetadata?.text)
         } finally {
             requestFile?.delete()
             responseFile?.delete()

--- a/client/apps/primaryapp/src/main/java/org/openpin/primaryapp/views/AnswerCardView.kt
+++ b/client/apps/primaryapp/src/main/java/org/openpin/primaryapp/views/AnswerCardView.kt
@@ -1,0 +1,30 @@
+package org.openpin.primaryapp.views
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.openpin.appframework.ui.components.CrossfadeText
+import org.openpin.appframework.ui.components.ScrollContainer
+
+/**
+ * Full-screen "answer card" projected while the assistant reply is being
+ * spoken: the reply text in large monochrome type. Long answers overflow
+ * into the standard [ScrollContainer] scroll affordances.
+ *
+ * The card carries no dismiss logic of its own; the caller pushes it when
+ * reply playback starts and pops it when playback finishes or is cancelled.
+ */
+@Composable
+fun AnswerCardView(text: String) {
+    ScrollContainer {
+        Spacer(modifier = Modifier.height(30.dp))
+        CrossfadeText(
+            text = text,
+            size = 64.sp,
+        )
+        Spacer(modifier = Modifier.height(30.dp))
+    }
+}


### PR DESCRIPTION
## What it does

While the assistant reply audio is playing, the client pushes a full-screen **answer card** onto the navigation stack that projects the reply text — large monochrome type via the existing `CrossfadeText`, inside the standard `ScrollContainer` so long answers get the usual chevron scroll affordances. The card auto-dismisses when playback completes, and also when playback is stopped by the existing cancel gesture (`handleCancel` → `speechPlayer.stop()` unblocks `awaitPlaybackCompletion`, and the card is popped in the same `finally`), restoring whatever view was underneath. Behavior with no text is unchanged: audio-only, no card.

## Where the text comes from (and an honest server-side gap)

`sendVoiceRequest()` now returns a `VoiceResponse` (TTS audio + optional reply text) instead of a bare `ByteArray`. The text is read from a new **optional `text` field in the 512-byte response metadata header** the protocol already reserves — fully backwards-compatible, older servers simply yield `null`.

The current server never sends the reply text, so out of the box the card will not appear yet:

- `sendResponse()` is always called with the default `{}` metadata; `assistantMsg` isn't passed through
- there's also a small bug in `sendResponse()` that zeroes the header regardless: `paddedMetadata.set(paddedMetadata)` should be `paddedMetadata.set(metadataBuffer)`

I deliberately kept this PR client-only. If you're open to it, the server side is a two-line follow-up (fix the `set()` call and pass `{ text: speech }` into `sendResponse` from `sendSpeech`), and the card lights up with no further client changes. Happy to send that PR too.

## Verification

- `./gradlew assembleDebug` green locally and on the fork's CI (branch carries the same one-file `client-ci.yml` compile-check workflow as my other open PRs — happy to rebase it out if unwanted)
- On-device verification pending hardware (my Pin's interposer is inbound), so this is compile-verified + code-reasoned only

🤖 Generated with [Claude Code](https://claude.com/claude-code)