### PR TITLE
Fix response metadata never reaching the device (self-copy bug); send reply text with assistant audio

### DIFF
--- a/server/src/endpoints/device/voice/assistant.ts
+++ b/server/src/endpoints/device/voice/assistant.ts
@@ -29,7 +29,14 @@ class Handler extends AbstractVoiceHandler {
       audioData = await addBackgroundAudio(audioData, SEXY_BG_AUDIO_FILE, SEXY_BG_AUDIO_CONFIG);
     }
 
-    await this.sendResponse(audioData);
+    // Include the spoken text so clients can render it (e.g. on the laser
+    // display) while the audio plays. 512-byte header cap: truncate long
+    // replies rather than erroring the whole response.
+    let text = speech;
+    while (Buffer.byteLength(JSON.stringify({ text }), "utf-8") + 1 > 512) {
+      text = text.slice(0, -8);
+    }
+    await this.sendResponse(audioData, { text });
   }
 
   public async run() {

--- a/server/src/endpoints/device/voice/common.ts
+++ b/server/src/endpoints/device/voice/common.ts
@@ -197,7 +197,7 @@ export class AbstractVoiceHandler {
     }
 
     const paddedMetadata = new Uint8Array(512);
-    paddedMetadata.set(paddedMetadata);
+    paddedMetadata.set(metadataBuffer);
 
     const body = Buffer.concat([paddedMetadata, audioData]);
     this.res.status(200).send(body);


### PR DESCRIPTION
## Bug
`sendResponse()` in `server/src/endpoints/device/voice/common.ts` serializes the metadata JSON, checks the 512-byte cap — and then copies the **zeroed padding buffer onto itself**:
```ts
const paddedMetadata = new Uint8Array(512);
paddedMetadata.set(paddedMetadata);   // <- no-op; metadataBuffer is never copied
```
Every device response ships 512 zero bytes where metadata should be. Fix: `paddedMetadata.set(metadataBuffer)`.

## Follow-up in the same PR
With the channel actually working, assistant responses now include `{ text: <spoken reply> }` (truncated to fit the cap), so clients can render the answer while the audio plays — this is what makes the answer-card client view in #15 functional. Existing clients that ignore the header are unaffected; the header was always designed to carry JSON (`Buffer.from(JSON.stringify(metadata))` + NUL).

## Verification
- `tsc --noEmit` clean.
- On-device verification pending hardware (revival project; interposer inbound) — noted per our other PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)